### PR TITLE
Fix boto3 client initialization to unblock CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Set up SAM CLI
         uses: aws-actions/setup-sam@v2
 
+      - name: Install AWS CLI
+        uses: aws-actions/setup-aws-cli@v2
+
       - name: Configure AWS credentials (assume role)
         if: secrets.AWS_DEPLOY_ROLE_ARN != ''
         uses: aws-actions/configure-aws-credentials@v4

--- a/src/handlers/photos.py
+++ b/src/handlers/photos.py
@@ -12,6 +12,12 @@ from typing import Any, Dict, Optional
 import boto3
 from botocore.exceptions import ClientError
 
+AWS_REGION = (
+    os.getenv("AWS_REGION")
+    or os.getenv("AWS_DEFAULT_REGION")
+    or "us-east-1"
+)
+
 LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.INFO)
 
@@ -24,8 +30,8 @@ ALLOWED_FAMILY_IDS = {
     if value.strip()
 }
 
-s3_client = boto3.client("s3")
-dynamodb_client = boto3.client("dynamodb")
+s3_client = boto3.client("s3", region_name=AWS_REGION)
+dynamodb_client = boto3.client("dynamodb", region_name=AWS_REGION)
 
 UPLOAD_URL_TTL_SECONDS = 15 * 60  # 15 minutes
 


### PR DESCRIPTION
## Summary
- default boto3 clients to a concrete AWS region so tests and CI can run without ambient configuration

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e0126265448323850666287721a0ff